### PR TITLE
[Changed] Support block on list methods

### DIFF
--- a/lib/belvo/resources.rb
+++ b/lib/belvo/resources.rb
@@ -25,11 +25,14 @@ module Belvo
 
     # List all results
     # @param params [Hash] Extra parameters sent as query strings.
-    # @return [Array]
+    # @return [Array] List of results when no block is passed.
+    # @yield [Hash] Each result to be processed individually.
     # @raise [RequestError] If response code is different than 2XX
     def list(params: nil)
-      results = []
-      @session.list(@endpoint, params: params) { |item| results.push item }
+      results = block_given? ? nil : []
+      @session.list(@endpoint, params: params) do |item|
+        results.nil? ? yield(item) : results.push(item)
+      end
       results
     end
 

--- a/spec/belvo/resource_spec.rb
+++ b/spec/belvo/resource_spec.rb
@@ -1,0 +1,32 @@
+RSpec.describe Belvo::RecurringExpenses do
+  describe '#list' do
+    let(:session) { instance_double('Belvo::APISession') }
+    let(:results) { %w[RESULT1 RESULT2 RESULT3] }
+    let(:params) { { foo: 'bar' } }
+    let(:resource) { described_class.new(session) }
+
+    before do
+      allow(session).to receive(:list)
+        .and_yield(results[0])
+        .and_yield(results[1])
+        .and_yield(results[2])
+    end
+
+    context 'when passing a block' do
+      it 'yields each result' do
+        yielded = []
+        response = resource.list { |result| yielded << result }
+        expect(response).to be_nil
+        expect(yielded).to eq(results)
+      end
+    end
+
+    context 'when not passing a block' do
+      subject(:list) { resource.list }
+
+      it 'returns all the results as array' do
+        expect(list).to eq(results)
+      end
+    end
+  end
+end


### PR DESCRIPTION
:question: What
---
Yield individual results on `Resource#list` method when a block is available. Otherwise return an array of results as usual.


:speech_balloon: Why
---
Some links may return large amounts of data (eg, transactions or invoices), causing memory errors on applications because all the results are held in memory at some point.

By processing individual results, applications may handle arbitrary larger sets of data.
