### PR TITLE
[Fixed] [BEL-14513] namespace issue

### DIFF
--- a/lib/belvo/resources.rb
+++ b/lib/belvo/resources.rb
@@ -86,8 +86,8 @@ module Belvo
       options: nil
     )
       options = LinkOptions.from(options)
-      options.certificate = Utils.read_file_to_b64(options.certificate)
-      options.private_key = Utils.read_file_to_b64(options.private_key)
+      options.certificate = ::Utils.read_file_to_b64(options.certificate)
+      options.private_key = ::Utils.read_file_to_b64(options.private_key)
       body = {
         institution: institution,
         username: username,
@@ -107,8 +107,8 @@ module Belvo
     # @raise [RequestError] If response code is different than 2XX
     def update(id:, password: nil, password2: nil, options: nil)
       options = LinkOptions.from(options)
-      options.certificate = Utils.read_file_to_b64(options.certificate)
-      options.private_key = Utils.read_file_to_b64(options.private_key)
+      options.certificate = ::Utils.read_file_to_b64(options.certificate)
+      options.private_key = ::Utils.read_file_to_b64(options.private_key)
       body = {
         password: password,
         password2: password2,

--- a/lib/belvo/resources.rb
+++ b/lib/belvo/resources.rb
@@ -86,8 +86,8 @@ module Belvo
       options: nil
     )
       options = LinkOptions.from(options)
-      options.certificate = ::Utils.read_file_to_b64(options.certificate)
-      options.private_key = ::Utils.read_file_to_b64(options.private_key)
+      options.certificate = Utils.read_file_to_b64(options.certificate)
+      options.private_key = Utils.read_file_to_b64(options.private_key)
       body = {
         institution: institution,
         username: username,
@@ -107,8 +107,8 @@ module Belvo
     # @raise [RequestError] If response code is different than 2XX
     def update(id:, password: nil, password2: nil, options: nil)
       options = LinkOptions.from(options)
-      options.certificate = ::Utils.read_file_to_b64(options.certificate)
-      options.private_key = ::Utils.read_file_to_b64(options.private_key)
+      options.certificate = Utils.read_file_to_b64(options.certificate)
+      options.private_key = Utils.read_file_to_b64(options.private_key)
       body = {
         password: password,
         password2: password2,

--- a/lib/belvo/utils.rb
+++ b/lib/belvo/utils.rb
@@ -3,12 +3,14 @@
 require 'base64'
 
 # Class with helper functions
-class Utils
-  def self.read_file_to_b64(path)
-    return if path.nil? || !File.file?(path)
-
-    data = File.open(path).read
-    Base64.encode64(data)
+module Belvo
+  class Utils
+    def self.read_file_to_b64(path)
+      return if path.nil? || !File.file?(path)
+  
+      data = File.open(path).read
+      Base64.encode64(data)
+    end
   end
 end
 

--- a/lib/belvo/utils.rb
+++ b/lib/belvo/utils.rb
@@ -2,12 +2,12 @@
 
 require 'base64'
 
-# Class with helper functions
 module Belvo
+  # Class with helper functions
   class Utils
     def self.read_file_to_b64(path)
       return if path.nil? || !File.file?(path)
-  
+
       data = File.open(path).read
       Base64.encode64(data)
     end

--- a/spec/belvo/utils_spec.rb
+++ b/spec/belvo/utils_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Utils do
+RSpec.describe Belvo::Utils do
   it 'read_file_to_b64 returns nil with bad file' do
     expect(described_class.read_file_to_b64('/bad/path')).to eq(nil)
   end


### PR DESCRIPTION
:question: What
---
As a developer I was experiencing some issues trying to create a link:

NoMethodError: undefined method `read_file_to_b64' for Belvo::Utils:Module
from /usr/local/bundle/ruby/2.6.0/gems/belvo-1.1.0/lib/belvo/resources.rb:89:in `register'


:speech_balloon: Why
---
Cloned the repo and configured my app for using the gem locally fixing the namespaces worked 

<!-- If this PR Relates or Fixes an issue, please also add it --> 
